### PR TITLE
Add Avalanche contract verification config

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -162,7 +162,17 @@ const config: HardhatUserConfig = {
     }
   },
   etherscan: {
-    apiKey: etherscanApiKey,
+    apiKey: {
+      arbitrumSepolia: etherscanApiKey,
+      arbitrumOne: etherscanApiKey,
+      ethereum: etherscanApiKey,
+      ethereumSepolia: etherscanApiKey,
+      baseSepolia: etherscanApiKey,
+      baseMainnet: etherscanApiKey,
+      xdcMainnet: 'empty',
+      xdcApothem: 'empty',
+      avalanche: 'empty',
+    },
     customChains: [
       {
         network: "xdcMainnet",
@@ -178,6 +188,14 @@ const config: HardhatUserConfig = {
         urls: {
           apiURL: "https://rpc.apothem.network/api",
           browserURL: "https://testnet.xdcscan.com"
+        }
+      },
+      {
+        network: "avalanche",
+        chainId: 43114,
+        urls: {
+          apiURL: "https://api.routescan.io/v2/network/mainnet/evm/43114/etherscan",
+          browserURL: "https://avalanche.routescan.io"
         }
       }
     ]


### PR DESCRIPTION
## Summary
- Switch etherscan apiKey from single string to per-chain map
- Add Avalanche customChains entry with Routescan API URL
- All 16 contracts verified on avalanche.routescan.io

## Test plan
- [x] `npx hardhat ignition verify chain-43114 --network avalanche --include-unrelated-contracts` passed